### PR TITLE
Remove redundant session_id parameter from detach_file method

### DIFF
--- a/sec-gemini-python/sec_gemini/session.py
+++ b/sec-gemini-python/sec_gemini/session.py
@@ -263,7 +263,7 @@ class InteractiveSession:
             logging.error(error_msg)
             return False
 
-        msg = f"[Session][DetachFile] session_id={self.id} {file_idx=}: OK"
+        msg = f"[Session][DetachFile] session_id={self.id}, file_idx={file_idx}: OK"
         logging.debug(msg)
         return True
 

--- a/sec-gemini-python/sec_gemini/session.py
+++ b/sec-gemini-python/sec_gemini/session.py
@@ -240,7 +240,7 @@ class InteractiveSession:
 
         return public_session_file
 
-    def detach_file(self, session_id: str, file_idx: int) -> bool:
+    def detach_file(self, file_idx: int) -> bool:
         """Detach a file from the session. The file to detach is indicated by
         its index in the `session.files` list.
         """
@@ -248,7 +248,7 @@ class InteractiveSession:
         resp = self.http.post(
             f"{_EndPoints.DETACH_FILE.value}",
             DetachFileRequest(
-                session_id=session_id,
+                session_id=self.id,
                 file_idx=file_idx,
             ),
         )
@@ -263,7 +263,7 @@ class InteractiveSession:
             logging.error(error_msg)
             return False
 
-        msg = f"[Session][DetachFile] {session_id=} {file_idx=}: OK"
+        msg = f"[Session][DetachFile] session_id={self.id} {file_idx=}: OK"
         logging.debug(msg)
         return True
 

--- a/sec-gemini-python/tests/test_secgemini.py
+++ b/sec-gemini-python/tests/test_secgemini.py
@@ -285,39 +285,39 @@ def test_session_attachments_apis(
         assert len(session.files) == test_file_idx + 1
     check_session_files(session.files, test_files_infos)
 
-    detach_res = session.detach_file(session.id, 3)
+    detach_res = session.detach_file(3)
     assert detach_res is False
     check_session_files(session.files, test_files_infos)
 
-    detach_res = session.detach_file(session.id, -1)
+    detach_res = session.detach_file(-1)
     assert detach_res is False
     check_session_files(session.files, test_files_infos)
 
-    detach_res = session.detach_file(session.id, 1)
+    detach_res = session.detach_file(1)
     test_files_infos.pop(1)
     assert detach_res is True
     check_session_files(session.files, test_files_infos)
 
-    detach_res = session.detach_file(session.id, 2)
+    detach_res = session.detach_file(2)
     assert detach_res is False
     check_session_files(session.files, test_files_infos)
 
-    detach_res = session.detach_file(session.id, 0)
+    detach_res = session.detach_file(0)
     test_files_infos.pop(0)
     assert detach_res is True
     check_session_files(session.files, test_files_infos)
 
-    detach_res = session.detach_file(session.id, 1)
+    detach_res = session.detach_file(1)
     assert detach_res is False
     check_session_files(session.files, test_files_infos)
 
-    detach_res = session.detach_file(session.id, 0)
+    detach_res = session.detach_file(0)
     test_files_infos.pop(0)
     assert detach_res is True
     check_session_files(session.files, test_files_infos)
     assert len(session.files) == 0
 
-    detach_res = session.detach_file(session.id, 0)
+    detach_res = session.detach_file(0)
     assert detach_res is False
 
 


### PR DESCRIPTION
### Description

Removes the `session_id` parameter from `session.detach_file()` since the session instance already has access to its ID via `self.id`.

**Changes:**
- Updated method signature: `detach_file(session_id: str, file_idx: int)` → `detach_file(file_idx: int)`
- Method now uses `self.id` instead of passed parameter
- Updated all test calls to use simplified API
- Fixed logging message

**First contribution note:** Assuming this change won't break existing external usage since the session object should manage its own identity rather than requiring callers to provide it.

### Testing:
- All imports work correctly
- Type checking passes with mypy
- Code compiles successfully

Fixes #59