### PR TITLE
Use created_at instead of timestamp in Message

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Patch
 
+- Support the new internal message timestamp logic
 - Fix bug where commands don't have time to terminate
 
 ## 0.0.4

--- a/cli/src/cli/interact/cmds.rs
+++ b/cli/src/cli/interact/cmds.rs
@@ -514,7 +514,7 @@ fn exec_session_list(input: CommandInput<'_>) -> CommandOutput<'_> {
             }
             println!(
                 " created {} ago ({} messages)",
-                HumanDuration(Duration::from_secs(now() - session.create_time as u64)),
+                HumanDuration(Duration::from_secs_f64(now() - session.create_time)),
                 session.num_messages
             );
         }

--- a/cli/src/sdk.rs
+++ b/cli/src/sdk.rs
@@ -151,7 +151,7 @@ impl Session {
     }
 
     pub async fn send(&mut self, prompt: &str) {
-        let message = MessageBuilder::new(MessageType::Query)
+        let message = MessageBuilder::new(self.id.clone(), MessageType::Query)
             .mime_type(Some("text/plain".to_string()))
             .content(Some(prompt.to_string()))
             .build();

--- a/cli/src/sdk/types.rs
+++ b/cli/src/sdk/types.rs
@@ -80,16 +80,19 @@ api! {
     pub struct Message MessageBuilder {
         pub id: String = uuid4_short(),
         pub parent_id: String = ROOT_ID.to_string(),
+        pub session_id: String,
         pub turn: String = uuid4_short(),
         pub group: String = uuid4(),
         pub actor: String = "user".to_string(),
         pub role: Role = Role::User,
-        pub timestamp: u64 = now(),
+        pub created_at: f64 = now(),
         pub message_type: MessageType,
+        pub icon: Option<String> = None,
+        pub text_color: Option<String> = None,
         pub title: Option<String> = None,
         pub state: State = State::Start,
         pub content: Option<String> = None,
-        pub mime_type: Option<MimeType> = None,
+        pub mime_type: Option<MimeType> = Some("text/plain".to_string()),
         pub status_code: u16 = 200,
         pub status_message: String = "OK".to_string(),
         pub usage: Option<Usage> = None,
@@ -149,8 +152,8 @@ api! {
         pub turns: u64 = 0,
         pub name: String,
         pub description: String,
-        pub create_time: f64 = now() as f64,
-        pub update_time: f64 = now() as f64,
+        pub create_time: f64 = now(),
+        pub update_time: f64 = now(),
         pub num_messages: u64 = 0,
         pub messages: Vec<Message> = Vec::new(),
         pub usage: Usage = UsageBuilder::new().build(),
@@ -242,8 +245,8 @@ api! {
     }
 }
 
-pub fn now() -> u64 {
-    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+pub fn now() -> f64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs_f64()
 }
 
 fn uuid4() -> String {


### PR DESCRIPTION
This needs to wait until deployed. It follows the https://github.com/google/sec-gemini/tree/new-message branch.