### PR TITLE
Disable PR summary from Gemini

### DIFF
--- a/cli/.gemini/config.yaml
+++ b/cli/.gemini/config.yaml
@@ -1,0 +1,3 @@
+code_review:
+  pull_request_opened:
+    summary: false


### PR DESCRIPTION
Do we want the PR summary? I think the reviews are enough. The summary is sometimes longer than the actual change, which makes no sense.